### PR TITLE
Run integration tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: node_js
+node_js:
+ - "4.0"
+before_script:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - sleep 3 # give xvfb some time to start
+script:
+  - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
- - "4.0"
+ - "6.9.1"
 before_script:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
+dist: trusty
+sudo: required
 language: node_js
 node_js:
  - "6.9.1"
-before_script:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - sleep 3 # give xvfb some time to start
-script:
-  - npm test
+before_install:
+ - export CHROME_BIN=/usr/bin/google-chrome
+ - export DISPLAY=:99.0
+ - sh -e /etc/init.d/xvfb start
+ - sudo apt-get update
+ - sudo apt-get install -y libappindicator1 fonts-liberation
+ - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+ - sudo dpkg -i google-chrome*.deb

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "gulp": "^3.9.1",
     "gulp-mocha": "^3.0.1",
     "gulp-webserver": "^0.9.1",
+    "package-json-versionify": "^1.0.3",
     "request-promise-native": "^1.0.3",
     "selenium-standalone": "^5.8.0",
     "selenium-webdriver": "^3.0.0-beta-3",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "uglifyjs": "^2.4.10"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=6.9.1"
   },
   "keywords": [
     "bittorrent",


### PR DESCRIPTION
Setup continuous integration tests on Travis.

 - Bump minimum node version for ES6 and dependencies
 - Setup `.travis.yml` to run Chrome headlessly with selenium